### PR TITLE
Add clang-tidy static analysis support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(ontologenius)
 
-include(cmake/ClangTidy.cmake)
+option(WITH_CLANG_TIDY "Enable clang-tidy static analysis during build" OFF)
+
+if(WITH_CLANG_TIDY)
+    include(cmake/ClangTidy.cmake)
+endif()
 
 function(add_onto_library TARGET)
     if(NOT TARGET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(ontologenius)
 
+include(cmake/ClangTidy.cmake)
+
 function(add_onto_library TARGET)
     if(NOT TARGET)
         message(FATAL_ERROR "Expected the target name as first argument")

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,0 +1,15 @@
+find_program(
+    CLANG_TIDY_EXE
+    NAMES clang-tidy clang-tidy-9 clang-tidy-8 clang-tidy-7 clang-tidy-6
+    DOC "Path to clang-tidy executable"
+)
+
+if(CLANG_TIDY_EXE)
+    set(CMAKE_CXX_CLANG_TIDY
+        ${CLANG_TIDY_EXE}
+        --checks=*,-abseil*,-android*,-fuchsia*,-modernize-use-trailing-return-type*,-zircon*,-objc*,-mpi*,-openmp*
+	#,-google-readability*,-readability*,-hicpp-braces*
+    )
+else()
+    message(WARNING "No executable for clang-tidy found. Building without clang-tidy.")
+endif()

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -7,8 +7,7 @@ find_program(
 if(CLANG_TIDY_EXE)
     set(CMAKE_CXX_CLANG_TIDY
         ${CLANG_TIDY_EXE}
-        --checks=*,-abseil*,-android*,-fuchsia*,-modernize-use-trailing-return-type*,-zircon*,-objc*,-mpi*,-openmp*,
-            -google-readability*,-readability*,-hicpp-braces*
+        --checks=*,-abseil*,-android*,-fuchsia*,-modernize-use-trailing-return-type*,-zircon*,-objc*,-mpi*,-openmp*,-google-readability*,-readability*,-hicpp-braces*
     )
 else()
     message(WARNING "No executable for clang-tidy found. Building without clang-tidy.")

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,14 +1,14 @@
 find_program(
     CLANG_TIDY_EXE
-    NAMES clang-tidy clang-tidy-9 clang-tidy-8 clang-tidy-7 clang-tidy-6
+    NAMES clang-tidy clang-tidy-9 clang-tidy-8 clang-tidy-7 clang-tidy-6.0
     DOC "Path to clang-tidy executable"
 )
 
 if(CLANG_TIDY_EXE)
     set(CMAKE_CXX_CLANG_TIDY
         ${CLANG_TIDY_EXE}
-        --checks=*,-abseil*,-android*,-fuchsia*,-modernize-use-trailing-return-type*,-zircon*,-objc*,-mpi*,-openmp*
-	#,-google-readability*,-readability*,-hicpp-braces*
+        --checks=*,-abseil*,-android*,-fuchsia*,-modernize-use-trailing-return-type*,-zircon*,-objc*,-mpi*,-openmp*,
+            -google-readability*,-readability*,-hicpp-braces*
     )
 else()
     message(WARNING "No executable for clang-tidy found. Building without clang-tidy.")


### PR DESCRIPTION
To start a build with clang-tidy, run the following command:
catkin_make -DWITH_CLANG_TIDY=ON