### PR TITLE
Adding the rdfs:comment support

### DIFF
--- a/include/ontologenius/API/ontologenius/clients/ontologyClients/OntologyClient.h
+++ b/include/ontologenius/API/ontologenius/clients/ontologyClients/OntologyClient.h
@@ -5,81 +5,86 @@
 
 namespace onto {
 
-/// @brief The OntologyClient class provides an abstraction common to all ontologenius exploration ROS services.
-/// The OntologyClient implements the functions common to every ontologenius exploration.
-/// This class is based on ClientBase and so ensure a persistent connection with the service based on.
-/// The persistent connection ensures a minimal response time.
-/// A reconnection logic is implemented in the event that the persistent connection fails. 
-class OntologyClient : public ClientBase
-{
-public:
-  /// @brief Constructs an ontology client.
-  /// Can be used in a multi-ontology mode by specifying the name of the ontology name.
-  /// @param name is the instance to be connected to. For classic use, name should be defined as "".
-  explicit OntologyClient(const std::string& name) : ClientBase(name)
+  /// @brief The OntologyClient class provides an abstraction common to all ontologenius exploration ROS services.
+  /// The OntologyClient implements the functions common to every ontologenius exploration.
+  /// This class is based on ClientBase and so ensure a persistent connection with the service based on.
+  /// The persistent connection ensures a minimal response time.
+  /// A reconnection logic is implemented in the event that the persistent connection fails.
+  class OntologyClient : public ClientBase
   {
-  }
+  public:
+    /// @brief Constructs an ontology client.
+    /// Can be used in a multi-ontology mode by specifying the name of the ontology name.
+    /// @param name is the instance to be connected to. For classic use, name should be defined as "".
+    explicit OntologyClient(const std::string& name) : ClientBase(name)
+    {
+    }
 
-  /// @brief Gives all concepts below the one specified in the parameter.
-  /// @param depth can be set to limit tree propagation to a specific value.
-  /// The default value -1 represents no propagation limitation.
-  /// @param selector can be set to only get results inheriting from the selector concept.
-  /// The default value "" represents no restriction on the result.
-  std::vector<std::string> getUp(const std::string& name, int depth = -1, const std::string& selector = "");
-  /// @brief Tests if a concept (individual, class, or property) inherit from another.
-  /// This function corresponds to checking if class_base is part of the result of the function getUp applies to the concept.
-  /// @param name is the name of the concept to be tested.
-  /// @param base_class is the name of the upper concept to be compared to.
-  /// @return Returns true if the concept is or inherits of the concept.
-  bool isA(const std::string& name, const std::string& base_class);
-  /// @brief Gives one of the label of a concept, that is not muted.
-  /// @param name is the concept indentifier for which you serach a label.
-  /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
-  /// @return The result of this function depends on the setting of the working language.
-  std::string getName(const std::string& name, bool take_id = true);
-  /// @brief Gives all the labels of a concept excepted the muted ones.
-  /// @param name is the concept indentifier for which you serach its labels.
-  /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
-  /// @return The result of this function depends on the setting of the working language.
-  std::vector<std::string> getNames(const std::string& name, bool take_id = true);
-  /// @brief Gives all the labels of a concept even the muted ones.
-  /// @param name is the concept indentifier for which you serach its labels.
-  /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
-  /// @return The result of this function depends on the setting of the working language.
-  std::vector<std::string> getEveryNames(const std::string& name, bool take_id = true);
-  /// @brief Gives all the concepts having for label the one passed in argument.
-  /// @param name is a concept name in natural language.
-  /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
-  /// @param selector can be set to only get results inheriting from the selector concept.
-  /// @return The result of this function depends on the setting of the working language.
-  std::vector<std::string> find(const std::string& name, bool take_id = true, const std::string& selector = "");
-  /// @brief Gives all the concepts having for label a subset of the one passed in argument.
-  /// @param name is a concept name in natural language.
-  /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
-  /// @param selector can be set to only get results inheriting from the selector concept.
-  /// @return The result of this function depends on the setting of the working language.
-  std::vector<std::string> findSub(const std::string& name, bool take_id = true, const std::string& selector = "");
-  /// @brief Gives all the concepts having a label matching the regular expression passed in argument.
-  /// @param regex is a regular expression.
-  /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
-  /// @param selector can be set to only get results inheriting from the selector concept.
-  /// @return The result of this function depends on the setting of the working language.
-  std::vector<std::string> findRegex(const std::string& regex, bool take_id = true, const std::string& selector = "");
-  /// @brief Gives all the names of concepts with the lowest edit distance with the name passed in argument.
-  /// @param name is a concept name in natural language.
-  /// @param threshold is the minimum editing distance.
-  /// This value corresponds to the number of changes to be made to pass from one
-  /// word to another divided by the length of the comparison word.
-  /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
-  /// @param selector can be set to only get results inheriting from the selector concept.
-  /// @return The result of this function depends on the setting of the working language.
-  std::vector<std::string> findFuzzy(const std::string& name, double threshold = 0.5, bool take_id = true, const std::string& selector = "");
-  /// @brief test if a concept exist in the subpart of the ontology managed by the client
-  /// (i.e. class, individuals, object properties, data properties).
-  /// @param name is a concept indentifier.
-  /// @return Returns true if the concept exists.
-  bool exist(const std::string& name);
-};
+    /// @brief Gives all concepts below the one specified in the parameter.
+    /// @param depth can be set to limit tree propagation to a specific value.
+    /// The default value -1 represents no propagation limitation.
+    /// @param selector can be set to only get results inheriting from the selector concept.
+    /// The default value "" represents no restriction on the result.
+    std::vector<std::string> getUp(const std::string& name, int depth = -1, const std::string& selector = "");
+    /// @brief Tests if a concept (individual, class, or property) inherit from another.
+    /// This function corresponds to checking if class_base is part of the result of the function getUp applies to the concept.
+    /// @param name is the name of the concept to be tested.
+    /// @param base_class is the name of the upper concept to be compared to.
+    /// @return Returns true if the concept is or inherits of the concept.
+    bool isA(const std::string& name, const std::string& base_class);
+    /// @brief Gives one of the label of a concept, that is not muted.
+    /// @param name is the concept indentifier for which you serach a label.
+    /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
+    /// @return The result of this function depends on the setting of the working language.
+    std::string getName(const std::string& name, bool take_id = true);
+    /// @brief Gives all the labels of a concept excepted the muted ones.
+    /// @param name is the concept indentifier for which you serach its labels.
+    /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
+    /// @return The result of this function depends on the setting of the working language.
+    std::vector<std::string> getNames(const std::string& name, bool take_id = true);
+    /// @brief Gives all the labels of a concept even the muted ones.
+    /// @param name is the concept indentifier for which you serach its labels.
+    /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
+    /// @return The result of this function depends on the setting of the working language.
+    std::vector<std::string> getEveryNames(const std::string& name, bool take_id = true);
+    /// @brief Gives all the concepts having for label the one passed in argument.
+    /// @param name is a concept name in natural language.
+    /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
+    /// @param selector can be set to only get results inheriting from the selector concept.
+    /// @return The result of this function depends on the setting of the working language.
+    std::vector<std::string> find(const std::string& name, bool take_id = true, const std::string& selector = "");
+    /// @brief Gives all the concepts having for label a subset of the one passed in argument.
+    /// @param name is a concept name in natural language.
+    /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
+    /// @param selector can be set to only get results inheriting from the selector concept.
+    /// @return The result of this function depends on the setting of the working language.
+    std::vector<std::string> findSub(const std::string& name, bool take_id = true, const std::string& selector = "");
+    /// @brief Gives all the concepts having a label matching the regular expression passed in argument.
+    /// @param regex is a regular expression.
+    /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
+    /// @param selector can be set to only get results inheriting from the selector concept.
+    /// @return The result of this function depends on the setting of the working language.
+    std::vector<std::string> findRegex(const std::string& regex, bool take_id = true, const std::string& selector = "");
+    /// @brief Gives all the names of concepts with the lowest edit distance with the name passed in argument.
+    /// @param name is a concept name in natural language.
+    /// @param threshold is the minimum editing distance.
+    /// This value corresponds to the number of changes to be made to pass from one
+    /// word to another divided by the length of the comparison word.
+    /// @param take_id can be set to false if you do not want to consider the concept identifier as a possible default name.
+    /// @param selector can be set to only get results inheriting from the selector concept.
+    /// @return The result of this function depends on the setting of the working language.
+    std::vector<std::string> findFuzzy(const std::string& name, double threshold = 0.5, bool take_id = true, const std::string& selector = "");
+    /// @brief test if a concept exist in the subpart of the ontology managed by the client
+    /// (i.e. class, individuals, object properties, data properties).
+    /// @param name is a concept indentifier.
+    /// @return Returns true if the concept exists.
+    bool exist(const std::string& name);
+    std::vector<std::string> getComments(const std::string& name, bool take_id = true);
+    /// @brief get the comments associated with the provided name, if it exists
+    /// (i.e. class, individual, object property, data property).
+    /// @param name is a concept/individual/object property/data property indentifier.
+    /// @return Returns the comments if the concept exists.
+  };
 
 } // namespace onto
 

--- a/include/ontologenius/core/ontoGraphs/Branchs/ValuedNode.h
+++ b/include/ontologenius/core/ontoGraphs/Branchs/ValuedNode.h
@@ -50,6 +50,7 @@ namespace ontologenius {
 
     Dictionary dictionary_;
     Dictionary steady_dictionary_;
+    Dictionary comment_dictionary_;
 
     template<typename C>
     void conditionalPushBack(std::vector<C>& vect, const C& data)
@@ -62,6 +63,7 @@ namespace ontologenius {
     void setSteadyMutedDictionary(const std::string& lang, const std::string& word);
     void setSteadyDictionary(const std::map<std::string, std::vector<std::string>>& dictionary);
     void setSteadyMutedDictionary(const std::map<std::string, std::vector<std::string>>& dictionary);
+    void setCommentDictionary(const std::map<std::string, std::vector<std::string>>& comment_dictionary);
 
     bool operator==(const std::string& other) const
     {

--- a/include/ontologenius/core/ontoGraphs/Graphs/ClassGraph.h
+++ b/include/ontologenius/core/ontoGraphs/Graphs/ClassGraph.h
@@ -23,6 +23,7 @@ namespace ontologenius {
     std::vector<PairElement<std::string, std::string>> object_relations_;
     std::vector<PairElement<std::string, std::string>> data_relations_;
     std::vector<std::string> equivalences_;
+    std::map<std::string, std::vector<std::string>> comments_;
   };
 
   class OntologyGraphs;

--- a/include/ontologenius/core/ontoGraphs/Graphs/DataPropertyGraph.h
+++ b/include/ontologenius/core/ontoGraphs/Graphs/DataPropertyGraph.h
@@ -26,6 +26,7 @@ namespace ontologenius {
     Properties_t properties_;
     std::map<std::string, std::vector<std::string>> dictionary_;
     std::map<std::string, std::vector<std::string>> muted_dictionary_;
+    std::map<std::string, std::vector<std::string>> comments_;
     bool annotation_usage_;
 
     DataPropertyDescriptor_t() : annotation_usage_(false) {}

--- a/include/ontologenius/core/ontoGraphs/Graphs/Graph.h
+++ b/include/ontologenius/core/ontoGraphs/Graphs/Graph.h
@@ -106,6 +106,8 @@ namespace ontologenius {
     template<typename T>
     std::unordered_set<T> findRegex(const std::string& regex, bool use_default = true);
     std::unordered_set<std::string> findFuzzy(const std::string& value, bool use_default = true, double threshold = 0.5);
+    template<typename T>
+    std::vector<std::string> getComments(const T& value, bool use_default = true);
 
     BranchContainerSet<B> container_;
     std::vector<B*> all_branchs_;
@@ -730,6 +732,24 @@ namespace ontologenius {
     return res;
   }
 
+  template<typename B>
+  template<typename T>
+  std::vector<std::string> Graph<B>::getComments(const T& value, bool use_default)
+  {
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    B* branch = findBranch(value);
+
+    std::vector<std::string> res;
+    if(branch != nullptr)
+    {
+      if(branch->comment_dictionary_.spoken_.find(language_) != branch->comment_dictionary_.spoken_.end())
+        res = branch->comment_dictionary_.spoken_[language_];
+      else if(use_default)
+        res.push_back(branch->value());
+    }
+
+    return res;
+  }
 } // namespace ontologenius
 
 #endif // ONTOLOGENIUS_GRAPH_H

--- a/include/ontologenius/core/ontoGraphs/Graphs/IndividualGraph.h
+++ b/include/ontologenius/core/ontoGraphs/Graphs/IndividualGraph.h
@@ -30,6 +30,7 @@ namespace ontologenius {
     // TODO : add vector distinct
     std::map<std::string, std::vector<std::string>> dictionary_;
     std::map<std::string, std::vector<std::string>> muted_dictionary_;
+    std::map<std::string, std::vector<std::string>> comments_;
   };
 
   class OntologyGraphs;

--- a/include/ontologenius/core/ontoGraphs/Graphs/ObjectPropertyGraph.h
+++ b/include/ontologenius/core/ontoGraphs/Graphs/ObjectPropertyGraph.h
@@ -27,6 +27,7 @@ namespace ontologenius {
     Properties_t properties_;
     std::map<std::string, std::vector<std::string>> dictionary_;
     std::map<std::string, std::vector<std::string>> muted_dictionary_;
+    std::map<std::string, std::vector<std::string>> comments_;
     bool annotation_usage_;
 
     ObjectPropertyDescriptor_t() : annotation_usage_(false) {}

--- a/include/ontologenius/core/ontoGraphs/Graphs/RuleGraph.h
+++ b/include/ontologenius/core/ontoGraphs/Graphs/RuleGraph.h
@@ -40,6 +40,7 @@ namespace ontologenius {
     std::vector<std::pair<RuleAtomDescriptor_t, std::vector<RuleVariableDescriptor_t>>> antecedents;
     std::vector<std::pair<RuleAtomDescriptor_t, std::vector<RuleVariableDescriptor_t>>> consequents;
     std::string rule_str;
+    std::map<std::string, std::vector<std::string>> comments_;
 
     std::string toString() const
     {

--- a/include/ontologenius/core/ontologyIO/Owl/OntologyOwlReader.h
+++ b/include/ontologenius/core/ontologyIO/Owl/OntologyOwlReader.h
@@ -97,6 +97,7 @@ namespace ontologenius {
     inline void push(std::vector<bool>& vect, bool elem, const std::string& symbole = "");
     void push(Properties_t& properties, tinyxml2::XMLElement* sub_elem, const std::string& symbole = "", const std::string& attribute = "rdf:resource");
     void pushLang(std::map<std::string, std::vector<std::string>>& dictionary, tinyxml2::XMLElement* sub_elem);
+    void pushComment(std::map<std::string, std::vector<std::string>>& dictionary, tinyxml2::XMLElement* sub_elem);
     inline std::string getName(const std::string& uri);
     inline float getProbability(tinyxml2::XMLElement* elem);
     inline std::string getAttribute(tinyxml2::XMLElement* elem, const std::string& attribute);

--- a/include/ontologenius/core/ontologyIO/Owl/writers/GraphOwlWriter.h
+++ b/include/ontologenius/core/ontologyIO/Owl/writers/GraphOwlWriter.h
@@ -40,6 +40,7 @@ namespace ontologenius {
 
     void writeDictionary(ValuedNode* node) const;
     void writeMutedDictionary(ValuedNode* node) const;
+    void writeCommentDictionary(ValuedNode* node) const;
 
     void writeString(const std::string& text, size_t level = 0) const;
 

--- a/ontopy/ontologenius/clients/OntologyClient.py
+++ b/ontopy/ontologenius/clients/OntologyClient.py
@@ -139,3 +139,11 @@ class OntologyClient(ClientBase):
            managed by the client (i.e. class, individuals, object properties, data properties).
         """
         return self.callStr("exist", name) != ''
+    
+    def getComments(self, name, take_id = True):
+        """Gives the comments associated to the concept name(str).
+        """
+        param = name
+        if take_id == False:
+            param += " -i false"
+        return self.call("getComments", param)

--- a/src/API/ontologenius/clients/ontologyClients/OntologyClient.cpp
+++ b/src/API/ontologenius/clients/ontologyClients/OntologyClient.cpp
@@ -102,4 +102,12 @@ namespace onto {
     return (callStr("exist", name).empty() == false);
   }
 
+  std::vector<std::string> OntologyClient::getComments(const std::string& name, bool take_id)
+  {
+    std::string param = name;
+    if(take_id == false)
+      param += " -i false";
+    return call("getComments", param);
+  }
+
 } // namespace onto

--- a/src/core/ontoGraphs/Branchs/ValuedNode.cpp
+++ b/src/core/ontoGraphs/Branchs/ValuedNode.cpp
@@ -66,4 +66,14 @@ namespace ontologenius {
     }
   }
 
+  void ValuedNode::setCommentDictionary(const std::map<std::string, std::vector<std::string>>& comment_dictionary)
+  {
+    for(const auto& lang_comment : comment_dictionary)
+    {
+      auto lang = lang_comment.first;
+      for(const auto& comment : lang_comment.second)
+        conditionalPushBack(comment_dictionary_.spoken_[lang], comment);
+    }
+  }
+
 } // namespace ontologenius

--- a/src/core/ontoGraphs/Graphs/ClassGraph.cpp
+++ b/src/core/ontoGraphs/Graphs/ClassGraph.cpp
@@ -78,6 +78,11 @@ namespace ontologenius {
     me->setSteadyDictionary(class_descriptor.dictionary_);
     me->setSteadyMutedDictionary(class_descriptor.muted_dictionary_);
 
+    /**********************
+    ** Comment
+    **********************/
+    me->setCommentDictionary(class_descriptor.comments_);
+
     mitigate(me);
     return me;
   }
@@ -1370,6 +1375,7 @@ namespace ontologenius {
 
     new_branch->dictionary_ = old_branch->dictionary_;
     new_branch->steady_dictionary_ = old_branch->steady_dictionary_;
+    new_branch->comment_dictionary_= old_branch->comment_dictionary_;
 
     for(const auto& child : old_branch->childs_)
       new_branch->childs_.emplace_back(child, container_.find(child.elem->value()));

--- a/src/core/ontoGraphs/Graphs/DataPropertyGraph.cpp
+++ b/src/core/ontoGraphs/Graphs/DataPropertyGraph.cpp
@@ -85,6 +85,11 @@ namespace ontologenius {
     me->setSteadyDictionary(property_descriptor.dictionary_);
     me->setSteadyMutedDictionary(property_descriptor.muted_dictionary_);
 
+    /**********************
+    ** Comment
+    **********************/
+    me->setCommentDictionary(property_descriptor.comments_);
+
     mitigate(me);
     return me;
   }
@@ -267,6 +272,7 @@ namespace ontologenius {
 
     new_branch->dictionary_ = old_branch->dictionary_;
     new_branch->steady_dictionary_ = old_branch->steady_dictionary_;
+    new_branch->comment_dictionary_= old_branch->comment_dictionary_;
 
     for(const auto& child : old_branch->childs_)
       new_branch->childs_.emplace_back(child, container_.find(child.elem->value()));

--- a/src/core/ontoGraphs/Graphs/IndividualGraph.cpp
+++ b/src/core/ontoGraphs/Graphs/IndividualGraph.cpp
@@ -97,6 +97,11 @@ namespace ontologenius {
     me->setSteadyDictionary(individual_descriptor.dictionary_);
     me->setSteadyMutedDictionary(individual_descriptor.muted_dictionary_);
 
+    /**********************
+    ** Comment
+    **********************/
+    me->setCommentDictionary(individual_descriptor.comments_);
+
     return me;
   }
 
@@ -2633,6 +2638,7 @@ namespace ontologenius {
 
     new_branch->dictionary_ = old_branch->dictionary_;
     new_branch->steady_dictionary_ = old_branch->steady_dictionary_;
+    new_branch->comment_dictionary_= old_branch->comment_dictionary_;
 
     for(const auto& is_a : old_branch->is_a_)
     {

--- a/src/core/ontoGraphs/Graphs/ObjectPropertyGraph.cpp
+++ b/src/core/ontoGraphs/Graphs/ObjectPropertyGraph.cpp
@@ -127,6 +127,11 @@ namespace ontologenius {
       me->str_chains_.push_back(chain_i);
     }
 
+    /**********************
+    ** Comment
+    **********************/
+    me->setCommentDictionary(property_descriptor.comments_);
+
     mitigate(me);
     return me;
   }
@@ -426,6 +431,7 @@ namespace ontologenius {
 
     new_branch->dictionary_ = old_branch->dictionary_;
     new_branch->steady_dictionary_ = old_branch->steady_dictionary_;
+    new_branch->comment_dictionary_= old_branch->comment_dictionary_;
 
     for(const auto& child : old_branch->childs_)
       new_branch->childs_.emplace_back(child, container_.find(child.elem->value()));

--- a/src/core/ontoGraphs/Graphs/RuleGraph.cpp
+++ b/src/core/ontoGraphs/Graphs/RuleGraph.cpp
@@ -44,6 +44,9 @@ namespace ontologenius {
     RuleBranch* rule_branch = new RuleBranch(rule_name, rule.rule_str);
     all_branchs_.push_back(rule_branch);
 
+    // add comment
+    rule_branch->setCommentDictionary(rule.comments_);
+
     size_t elem_id = 0;
 
     for(const auto& atom : rule.antecedents)
@@ -157,6 +160,8 @@ namespace ontologenius {
     new_branch->nb_updates_ = old_branch->nb_updates_;
     new_branch->setUpdated(old_branch->isUpdated());
     new_branch->flags_ = old_branch->flags_;
+
+    new_branch->comment_dictionary_= old_branch->comment_dictionary_;
 
     // addon
     new_branch->involves_class = old_branch->involves_class;

--- a/src/core/ontologyIO/Owl/OntologyOwlReader.cpp
+++ b/src/core/ontologyIO/Owl/OntologyOwlReader.cpp
@@ -610,7 +610,7 @@ namespace ontologenius {
     }
   }
 
-  void OntologyOwlReader::pushComment(std::map<std::string, std::vector<std::string>>& dict_comment, tinyxml2::XMLElement* sub_elem)
+  void OntologyOwlReader::pushComment(std::map<std::string, std::vector<std::string>>& dictionary, tinyxml2::XMLElement* sub_elem)
   {
     const char* sub_attr = sub_elem->Attribute("xml:lang");
     if(sub_attr != nullptr)
@@ -620,9 +620,9 @@ namespace ontologenius {
       const char* value = sub_elem->GetText();
       if(value != nullptr)
       {
-        dict_comment[lang].emplace_back(value);
+        dictionary[lang].emplace_back(value);
         if((lang.empty() == false) && (std::string(value).empty() == false) && display_)
-          std::cout << "│   │   ├── " << "#" << lang << " : " << dict_comment[lang][dict_comment[lang].size() - 1] << std::endl;
+          std::cout << "│   │   ├── " << "#" << lang << " : " << dictionary[lang][dictionary[lang].size() - 1] << std::endl;
       }
     }
   }

--- a/src/core/ontologyIO/Owl/OntologyOwlReader.cpp
+++ b/src/core/ontologyIO/Owl/OntologyOwlReader.cpp
@@ -225,6 +225,8 @@ namespace ontologenius {
           pushLang(class_descriptor.dictionary_, sub_elem);
         else if(sub_elem_name == "onto:label")
           pushLang(class_descriptor.muted_dictionary_, sub_elem);
+        else if(sub_elem_name == "rdfs:comment")
+          pushComment(class_descriptor.comments_, sub_elem);
         else if(sub_elem_name == "owl:equivalentClass")
           anonymous_descriptor.expression_members.emplace_back(readEquivalentClass(sub_elem));
         else
@@ -281,6 +283,8 @@ namespace ontologenius {
           pushLang(individual_descriptor.dictionary_, sub_elem);
         else if(sub_elem_name == "onto:label")
           pushLang(individual_descriptor.muted_dictionary_, sub_elem);
+        else if(sub_elem_name == "rdfs:comment")
+          pushComment(individual_descriptor.comments_, sub_elem);
         else
         {
           const std::string ns = sub_elem_name.substr(0, sub_elem_name.find(':'));
@@ -413,6 +417,8 @@ namespace ontologenius {
           pushLang(property_vector.dictionary_, sub_elem);
         else if(sub_elem_name == "onto:label")
           pushLang(property_vector.muted_dictionary_, sub_elem);
+        else if(sub_elem_name == "rdfs:comment")
+          pushComment(property_vector.comments_, sub_elem);
         else if(sub_elem_name == "owl:propertyChainAxiom")
         {
           std::vector<std::string> tmp;
@@ -454,6 +460,8 @@ namespace ontologenius {
           pushLang(property_vector.dictionary_, sub_elem);
         else if(sub_elem_name == "onto:label")
           pushLang(property_vector.muted_dictionary_, sub_elem);
+        else if(sub_elem_name == "rdfs:comment")
+          pushComment(property_vector.comments_, sub_elem);
       }
     }
 
@@ -598,6 +606,23 @@ namespace ontologenius {
 
         if((lang.empty() == false) && (std::string(value).empty() == false) && display_)
           std::cout << "│   │   ├── " << "@" << lang << " : " << dictionary[lang][dictionary[lang].size() - 1] << std::endl;
+      }
+    }
+  }
+
+  void OntologyOwlReader::pushComment(std::map<std::string, std::vector<std::string>>& dict_comment, tinyxml2::XMLElement* sub_elem)
+  {
+    const char* sub_attr = sub_elem->Attribute("xml:lang");
+    if(sub_attr != nullptr)
+    {
+      const std::string lang = std::string(sub_attr);
+
+      const char* value = sub_elem->GetText();
+      if(value != nullptr)
+      {
+        dict_comment[lang].emplace_back(value);
+        if((lang.empty() == false) && (std::string(value).empty() == false) && display_)
+          std::cout << "│   │   ├── " << "#" << lang << " : " << dict_comment[lang][dict_comment[lang].size() - 1] << std::endl;
       }
     }
   }

--- a/src/core/ontologyIO/Owl/OntologyOwlRuleReader.cpp
+++ b/src/core/ontologyIO/Owl/OntologyOwlRuleReader.cpp
@@ -15,6 +15,11 @@ namespace ontologenius {
   RuleDescriptor_t OntologyOwlReader::readRuleDescription(tinyxml2::XMLElement* elem)
   {
     RuleDescriptor_t rule;
+
+    // read comment
+    auto* rule_comment = elem->FirstChildElement("rdfs:comment");
+    pushComment(rule.comments_, rule_comment);
+
     // read body
     auto* rule_body = elem->FirstChildElement("swrl:body");
     if(rule_body == nullptr)

--- a/src/core/ontologyIO/Owl/writers/ClassOwlWriter.cpp
+++ b/src/core/ontologyIO/Owl/writers/ClassOwlWriter.cpp
@@ -60,6 +60,8 @@ namespace ontologenius {
     writeDictionary(branch);
     writeMutedDictionary(branch);
 
+    writeCommentDictionary(branch);
+
     writeBranchEnd();
   }
 

--- a/src/core/ontologyIO/Owl/writers/DataPropertiesOwlWriter.cpp
+++ b/src/core/ontologyIO/Owl/writers/DataPropertiesOwlWriter.cpp
@@ -46,6 +46,8 @@ namespace ontologenius {
     writeDictionary(branch);
     writeMutedDictionary(branch);
 
+    writeCommentDictionary(branch);
+
     writeBranchEnd();
   }
 

--- a/src/core/ontologyIO/Owl/writers/GraphOwlWriter.cpp
+++ b/src/core/ontologyIO/Owl/writers/GraphOwlWriter.cpp
@@ -72,4 +72,20 @@ namespace ontologenius {
     }
   }
 
+  void GraphOwlWriter::writeCommentDictionary(ValuedNode* node) const
+  {
+    for(const auto& it : node->comment_dictionary_.spoken_)
+    {
+      for(const auto& label : it.second)
+      {
+        const std::string tmp = "<rdfs:comment xml:lang=\"" +
+                                it.first +
+                                "\">" +
+                                label +
+                                +"</rdfs:comment>\n";
+        writeString(tmp, 2);
+      }
+    }
+  }
+
 } // namespace ontologenius

--- a/src/core/ontologyIO/Owl/writers/IndividualOwlWriter.cpp
+++ b/src/core/ontologyIO/Owl/writers/IndividualOwlWriter.cpp
@@ -51,6 +51,8 @@ namespace ontologenius {
     writeDictionary(branch);
     writeMutedDictionary(branch);
 
+    writeCommentDictionary(branch);
+
     writeBranchEnd();
   }
 

--- a/src/core/ontologyIO/Owl/writers/ObjectPropertiesOwlWriter.cpp
+++ b/src/core/ontologyIO/Owl/writers/ObjectPropertiesOwlWriter.cpp
@@ -56,6 +56,8 @@ namespace ontologenius {
     writeDictionary(branch);
     writeMutedDictionary(branch);
 
+    writeCommentDictionary(branch);
+
     writeBranchEnd();
   }
 

--- a/src/core/ontologyIO/Owl/writers/RuleOwlWriter.cpp
+++ b/src/core/ontologyIO/Owl/writers/RuleOwlWriter.cpp
@@ -41,6 +41,8 @@ namespace ontologenius {
     const std::string field = "rdf:Description";
 
     writeString("<" + field + ">\n", level);
+    writeCommentDictionary(branch);
+
     writeString("<rdf:type rdf:resource=\"http://www.w3.org/2003/11/swrl#Imp\"/>\n", level + 1);
 
     // write the body of the rule

--- a/src/interface/RosInterfaceStringHandlers.cpp
+++ b/src/interface/RosInterfaceStringHandlers.cpp
@@ -88,6 +88,8 @@ namespace ontologenius {
         }
         else if(req->action == "getAll")
           res->values = onto_->classes_.getAll();
+        else if(req->action == "getComments")
+          res->values = onto_->classes_.getComments(params(), params.take_id);
         else
           res->code = UNKNOW_ACTION;
 
@@ -172,6 +174,8 @@ namespace ontologenius {
         }
         else if(req->action == "getAll")
           res->values = onto_->object_properties_.getAll();
+        else if(req->action == "getComments")
+          res->values = onto_->object_properties_.getComments(params(), params.take_id);
         else
           res->code = UNKNOW_ACTION;
 
@@ -252,6 +256,8 @@ namespace ontologenius {
         }
         else if(req->action == "getAll")
           res->values = onto_->data_properties_.getAll();
+        else if(req->action == "getComments")
+          res->values = onto_->data_properties_.getComments(params(), params.take_id);
         else
           res->code = UNKNOW_ACTION;
 
@@ -362,6 +368,8 @@ namespace ontologenius {
           res->values = onto_->individuals_.getInferenceExplanation(params());
         else if(req->action == "getInferenceRule")
           res->values = {onto_->individuals_.getInferenceRule(params())};
+        else if(req->action == "getComments")
+          res->values = onto_->individuals_.getComments(params(), params.take_id);
         else
           res->code = UNKNOW_ACTION;
 


### PR DESCRIPTION
Adding the support for comments on classes, object and data properties, individuals and SWRL rules.
Added in Python API only.
Needed to add it into the C++ API, GUI and documentation. 